### PR TITLE
Use new cisagov/ansible-role-remove-python2 role

### DIFF
--- a/src/base.yml
+++ b/src/base.yml
@@ -4,8 +4,6 @@
   become: yes
   become_method: sudo
   roles:
-    - upgrade
-    - python
     - banner
     - dev_ssh_access
     - persist_journald

--- a/src/packer.json
+++ b/src/packer.json
@@ -63,6 +63,10 @@
   ],
   "provisioners": [
     {
+      "playbook_file": "src/upgrade.yml",
+      "type": "ansible"
+    },
+    {
       "playbook_file": "src/python.yml",
       "type": "ansible"
     },

--- a/src/python.yml
+++ b/src/python.yml
@@ -4,19 +4,6 @@
   become: yes
   become_method: sudo
   roles:
+    - remove_python2
     - pip
     - python
-  tasks:
-    - name: Remove python2 installation
-      apt:
-        name:
-          - python
-          - python-dev
-          # This is the package that actually provides
-          # /usr/bin/python.  We want /usr/bin/python to not exist,
-          # since if it does then Ansible will use it as its python.
-          - python-minimal
-          - python-pip
-        state: absent
-        # This gets rid of any dangling python2 packages
-        autoremove: yes

--- a/src/python.yml
+++ b/src/python.yml
@@ -4,6 +4,6 @@
   become: yes
   become_method: sudo
   roles:
-    - remove_python2
     - pip
     - python
+    - remove_python2

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -22,6 +22,8 @@
   name: pip
 - src: https://github.com/cisagov/ansible-role-python
   name: python
+- src: https://github.com/cisagov/ansible-role-remove-python2
+  name: remove_python2
 - src: https://github.com/cisagov/ansible-role-ufw
   name: ufw
 - src: https://github.com/cisagov/ansible-role-upgrade

--- a/src/upgrade.yml
+++ b/src/upgrade.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  name: Upgrade base image
+  become: yes
+  become_method: sudo
+  roles:
+    - upgrade

--- a/src/version.txt
+++ b/src/version.txt
@@ -1,1 +1,1 @@
-__version__ = "0.0.1"
+__version__ = "0.0.1+build.1"


### PR DESCRIPTION
## 🗣 Description

This pull request removes some tasks in the `python.yml` file and instead uses the [cisagov/ansible-role-remove-python2](https://github.com/cisagov/ansible-role-remove-python2) Ansible role.

## 💭 Motivation and Context

I wanted to verify that switching to the Ansible role does not break the build.

## 🧪 Testing

I have used these changes to successfully build a teamserver AMI.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
