### PR TITLE
Fix capitalization in task names

### DIFF
--- a/src/cobalt_strike.yml
+++ b/src/cobalt_strike.yml
@@ -10,7 +10,7 @@
         bucket_name: "{{ build_bucket }}"
     - server_setup
   tasks:
-    - name: Install thunderbird mail client
+    - name: Install Thunderbird mail client
       package:
         name: thunderbird
     - name: Install some tools manually
@@ -54,7 +54,7 @@
           - dir_name: "Malleable-C2-Randomizer"
             repo: |
               https://github.com/bluscreenofjeff/Malleable-C2-Randomizer/tarball/master
-    - name: Install mono for the manually installed packages that need it
+    - name: Install Mono for the manually installed packages that need it
       package:
         name:
           - mono-complete


### PR DESCRIPTION
## 🗣 Description ##

This pull request fixes capitalization issues in two task names.

## 💭 Motivation and Context ##

@dav3r and @mcdonnnj asked for these changes in cisagov/kali-packer#44.  Since this repository is where I copied the `cobalt_strike.yml` file from, it only makes sense to make the same changes here as well.

## 🧪 Testing ##

All pre-commit hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
